### PR TITLE
Add feature and fix ahi_hsd reader's scheduled_time

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -51,3 +51,4 @@ The following people have made contributions to this project:
 - [oananicola (oananicola)](https://github.com/oananicola)
 - [praerien (praerien)](https://github.com/praerien)
 - [Xin Zhang (zxdawn)](https://github.com/zxdawn)
+- [Taiga Tsukada (tsukada-cs)](https://github.com/tsukada-cs)

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -309,7 +309,13 @@ class AHIHSDFileHandler(BaseFileHandler):
     def scheduled_time(self):
         """Time this band was scheduled to be recorded."""
         timeline = "{:04d}".format(self.basic_info['observation_timeline'][0])
-        return self.start_time.replace(hour=int(timeline[:2]), minute=int(timeline[2:4]), second=0, microsecond=0)
+        if self.observation_area == 'FLDK':
+            dt = 0
+        else:
+            observation_freq = {'JP': 150, 'R3': 150, 'R4': 30, 'R5': 30}[self.observation_area[:2]]
+            dt = observation_freq * (int(self.observation_area[2:]) - 1)
+        return self.start_time.replace(hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
+                                       second=dt % 60, microsecond=0)
 
     def get_dataset(self, key, info):
         return self.read_band(key, info)

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""The abi_l1b reader tests package.
+"""The ahi_hsd reader tests package.
 """
 
 import unittest
@@ -71,9 +71,10 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             'spare': ''}
 
             area_def = fh.get_area_def(None)
-            self.assertEqual(area_def.proj_dict, {'a': 6378137.0, 'b': 6356752.3,
-                                                  'h': 35785863.0, 'lon_0': 140.7,
-                                                  'proj': 'geos', 'units': 'm'})
+            self.assertEqual(area_def.proj_dict, {'proj': 'geos', 'lon_0': 140.7,
+                                                  'h': 35785863.0, 'x_0': 0, 'y_0': 0,
+                                                  'a': 6378137.0, 'b': 6356752.3, 'units': 'm',
+                                                  'no_defs': None, 'type': 'crs'})
 
             self.assertEqual(area_def.area_extent, (592000.0038256244, 4132000.026701824,
                                                     1592000.0102878278, 5132000.033164027))
@@ -113,9 +114,10 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             'spare': ''}
 
             area_def = fh.get_area_def(None)
-            self.assertEqual(area_def.proj_dict, {'a': 6378137.0, 'b': 6356752.3,
-                                                  'h': 35785863.0, 'lon_0': 140.7,
-                                                  'proj': 'geos', 'units': 'm'})
+            self.assertEqual(area_def.proj_dict, {'proj': 'geos', 'lon_0': 140.7,
+                                                  'h': 35785863.0, 'x_0': 0, 'y_0': 0,
+                                                  'a': 6378137.0, 'b': 6356752.3, 'units': 'm',
+                                                  'no_defs': None, 'type': 'crs'})
 
             self.assertEqual(area_def.area_extent, (-5500000.035542117, -3300000.021325271,
                                                     5500000.035542117, -2200000.0142168473))
@@ -164,10 +166,12 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                             'number_of_lines': 1100,
                             'spare': ''}
             fh.basic_info = {
+                'observation_area': np.array(['FLDK']),
                 'observation_start_time': np.array([58413.12523839]),
                 'observation_end_time': np.array([58413.12562439]),
                 'observation_timeline': np.array([300]),
             }
+            fh.observation_area = np2str(fh.basic_info['observation_area'])
 
             self.fh = fh
 


### PR DESCRIPTION
Fix `scheduled_time` handling in ahi_hsd reader

Added min and sec information to `scheduled_time` of ahi_hsd reader.
The `scheduled_time` had an accuracy of 10 min, but the Japan region (JPee) and Region 3 (R3ff) are observed at a frequency of 150 sec.
Regions 4 (R4gg) and 5 (R5ii) of non-public data are observed at a frequency of 30 sec.
Detailed information on the data is found [here](http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/hsd_sample/HS_D_users_guide_en_v13.pdf).
With this fix, `scheduled_time` is calculated correctly for those observations.

 - [x] Tests added and test suite added to parent suite
 - [x] Tests passed
 - [x] Passes ``flake8 satpy``
 - [x] Add your name to `AUTHORS.md` if not there already
